### PR TITLE
Update dependency on sunspot

### DIFF
--- a/sunspot-rails-tester.gemspec
+++ b/sunspot-rails-tester.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_path  = 'lib'
 
-  s.add_dependency 'sunspot_rails'
-  s.add_dependency 'sunspot_solr'
+  s.add_dependency 'sunspot_rails', '>= 1.2'
+  s.add_dependency 'sunspot_solr', '>= 1.2'
 
   s.add_development_dependency 'rspec', '~> 2.5'
 end


### PR DESCRIPTION
I'd like to use sunspot-rais-tester on sunspot 2.0.0.pre.
