### PR TITLE
kill the sunspot server properly on sunspot 2.2.1

### DIFF
--- a/lib/sunspot/rails/tester.rb
+++ b/lib/sunspot/rails/tester.rb
@@ -30,7 +30,13 @@ module Sunspot
         end
         
         def kill_at_exit
-          at_exit { Process.kill('TERM', pid) }
+          at_exit {
+            Process.kill('TERM', pid)
+            if port && server.respond_to?(:exec_in_solr_executable_directory)
+              command = ['./solr', 'stop', '-p', "#{port}"]
+              server.exec_in_solr_executable_directory(command)
+            end
+          }
         end
         
         def give_feedback


### PR DESCRIPTION
Sunspot 2.2.1 uses solr5.
Sending `TERM` to the sunspot server process doesn't kill solr properly.
https://github.com/sunspot/sunspot/commit/2790bda3765f8618cb85169a49c88119a46da228
